### PR TITLE
Resolve variable interpolation issue in repository cloning

### DIFF
--- a/antgo/pipeline/engine/operator_loader.py
+++ b/antgo/pipeline/engine/operator_loader.py
@@ -137,7 +137,7 @@ class OperatorLoader:
         os.makedirs(ANTGO_DEPEND_ROOT, exist_ok=True)
         if not os.path.exists(os.path.join(ANTGO_DEPEND_ROOT, 'eagleeye', 'py')):
             if not os.path.exists(os.path.join(ANTGO_DEPEND_ROOT, 'eagleeye')):
-                os.system('cd {ANTGO_DEPEND_ROOT} && git clone https://github.com/jianzfb/eagleeye.git')
+                os.system(f'cd {ANTGO_DEPEND_ROOT} && git clone https://github.com/jianzfb/eagleeye.git')
 
             if 'darwin' in sys.platform:
                 os.system(f'cd {ANTGO_DEPEND_ROOT}/eagleeye && bash osx_build.sh BUILD_PYTHON_MODULE')


### PR DESCRIPTION
# PR Summary
This PR addresses a path resolution issue where the `cd` command attempted to access a literal `{ANTGO_DEPEND_ROOT}` directory instead of the intended variable value. By adding f-string formatting, the variable now interpolates correctly, ensuring the repository is cloned into the proper path.